### PR TITLE
Add a script to automatically decompress raw .rec files straight from R6

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rec filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 venv/
+scratch/

--- a/Parser/binary_utils.py
+++ b/Parser/binary_utils.py
@@ -1,0 +1,35 @@
+import struct
+
+
+def decode_integer(hex_bytes):
+    """
+    Decode a bytes object in little endian notation into its integer form
+    :param hex_bytes: a bytes object with a length of either 2, 4, or 8
+    :return: the integer represented in the given bytes
+    """
+    if len(hex_bytes) == 2:
+        return struct.unpack("<H", hex_bytes)[0]
+    elif len(hex_bytes) == 4:
+        return struct.unpack("<I", hex_bytes)[0]
+    elif len(hex_bytes) == 8:
+        return struct.unpack("<Q", hex_bytes)[0]
+    else:
+        raise ValueError(f"ByteString: {bytes_to_hex_string(hex_bytes)} is of incorrect length")
+
+
+def bytes_to_hex_string(hex_bytes):
+    hex_str = hex_bytes.hex().upper()
+    return ' '.join([hex_str[i:i + 4] for i in range(0, len(hex_str), 4)])
+
+
+def print_block(hex_bytes, explanation, args):
+    print("--------------------------" * 5)
+    if not args.hide_source_bytes:
+        hex_string = bytes_to_hex_string(hex_bytes)
+        if len(hex_string) > (args.column_width - 10):
+            hex_string = hex_string[:args.column_width - 13] + "..."
+
+        print(hex_string, end='')
+        print(' ' * (args.column_width - len(hex_string)), end='')
+
+    print(explanation)

--- a/Parser/decompress_raw_file.py
+++ b/Parser/decompress_raw_file.py
@@ -1,0 +1,93 @@
+import sys
+
+import zstandard
+import argparse
+import io
+
+from Parser import zst_utils
+from Parser.binary_utils import bytes_to_hex_string
+from Parser.zst_utils import find_last_zst_header
+
+last_bytes = b'\x00\x00\x00\x00\x49\xcc\xd5\x76\xf4\x05\x5a\x22'
+
+
+def display_warning(args, warning_text):
+    print(warning_text)
+    fail_if_not_forced(args)
+
+
+def fail_if_not_forced(args):
+    if args.force:
+        return
+    else:
+        print("\n\nParsing stopped. No output written.\n(You can override this behavior using the -f flag)")
+        sys.exit(9)
+
+
+def decompress_stream_to_output_file(args, input_stream, bytes_to_read=-1):
+    with open(args.out_file, 'wb') as of:
+        decompressor = zstandard.ZstdDecompressor()
+        decompressor.copy_stream(input_stream, of)
+
+
+def main(args):
+    with open(args.input_file, 'rb') as f:
+        if args.is_zst:
+            # The footer has been pre-stripped for us,
+            # so we only need to decompress using the standard ZST library function
+            decompress_stream_to_output_file(args, f)
+        else:
+            # We need to strip the footer from the rec file
+            # before feeding it to the ZST library function
+            in_memory_copy = io.BytesIO(f.read())
+            buffer = in_memory_copy.getbuffer()
+
+            actual_last_bytes = buffer[-len(last_bytes):]
+            if actual_last_bytes != last_bytes:
+                display_warning(args, f"WARNING: This doesn't look like a .rec file. "
+                                      f"The last {len(last_bytes)} bytes didn't match the expected value.\n"
+                                      f"Expected Value:\t\t{bytes_to_hex_string(actual_last_bytes)}\n"
+                                      f"Actual Value:\t\t{bytes_to_hex_string(last_bytes)}")
+
+            # Find the last frame in the ZST file
+            last_zst_header_addr = find_last_zst_header(buffer)
+
+            if last_zst_header_addr is None:
+                display_warning(args, f"WARNING: This doesn't look like a .rec file. Couldn't find any ZST"
+                                      f" magic number bytes")
+            last_zst_header_bytes = bytes(buffer[last_zst_header_addr:last_zst_header_addr+25])
+            frame_header_size = zstandard.frame_header_size(last_zst_header_bytes)
+
+            # Read through each block in this last frame to find the location of the end of the file
+            block_params = zst_utils.parse_block_header(last_zst_header_bytes[frame_header_size:frame_header_size+3])
+            next_block_addr = last_zst_header_addr + frame_header_size + 3 + block_params.block_size
+
+            while not block_params.last_block:
+                block_params = zst_utils.parse_block_header(bytes(buffer[next_block_addr:next_block_addr+3]))
+                next_block_addr += 3 + block_params.block_size
+
+            # The next byte after the last block in the last frame is outside of the ZST file, giving us the length
+            size_of_zst_file = next_block_addr
+
+            # Only grab the first portion of the file (which is simply a ZST file)
+            in_memory_copy.seek(0)
+            zst_file_in_memory = io.BytesIO(in_memory_copy.read(size_of_zst_file))
+
+            # Decompress and write to output file
+            decompress_stream_to_output_file(args, zst_file_in_memory)
+
+
+
+
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Decompresses an entire .rec file")
+    parser.add_argument('input_file', metavar='input_file', type=str, help="The file to decompress")
+    parser.add_argument('out_file', metavar='output_file', type=str, help="The file path to write to")
+    parser.add_argument('-z', '--is-zst', action='store_true', help="Indicate that the input file is already in ZST "
+                                                                    "format (no need to strip the footer)")
+    parser.add_argument('-f', '--force', action='store_true', help="Force the parser to continue despite warnings")
+
+    main(parser.parse_args())

--- a/Parser/parse_round_header.py
+++ b/Parser/parse_round_header.py
@@ -1,39 +1,11 @@
-import struct
 import argparse
+
+from Parser.binary_utils import decode_integer, print_block
 
 header_properties = []
 
 packet_ids = []
 packet_timestamps = []
-
-
-def decode_integer(hex_bytes):
-    if len(hex_bytes) == 2:
-        return struct.unpack("<H", hex_bytes)[0]
-    elif len(hex_bytes) == 4:
-        return struct.unpack("<I", hex_bytes)[0]
-    elif len(hex_bytes) == 8:
-        return struct.unpack("<Q", hex_bytes)[0]
-    else:
-        raise ValueError(f"ByteString: {bytes_to_hex_string(hex_bytes)} is of incorrect length")
-
-
-def bytes_to_hex_string(hex_bytes):
-    hex_str = hex_bytes.hex().upper()
-    return ' '.join([hex_str[i:i + 4] for i in range(0, len(hex_str), 4)])
-
-
-def print_block(hex_bytes, explanation, args):
-    print("--------------------------" * 5)
-    if not args.hide_source_bytes:
-        hex_string = bytes_to_hex_string(hex_bytes)
-        if len(hex_string) > (args.column_width - 10):
-            hex_string = hex_string[:args.column_width - 13] + "..."
-
-        print(hex_string, end='')
-        print(' ' * (args.column_width - len(hex_string)), end='')
-
-    print(explanation)
 
 
 def read_string(bytestream):

--- a/Parser/zst_utils.py
+++ b/Parser/zst_utils.py
@@ -1,0 +1,28 @@
+import binary_utils
+
+zst_file_magic_number = b'\x28\xB5\x2F\xFD'
+
+class BlockParameters(object):
+    block_size: int
+    block_type: int
+    last_block: bool
+
+def find_last_zst_header(buffer):
+    for i in range(len(buffer)):
+        if bytes(buffer[-(i+4):-i]) == zst_file_magic_number:
+            return len(buffer) - (i + 4)
+
+
+def parse_block_header(block_header_bytes):
+    if len(block_header_bytes) != 3:
+        raise ValueError(f"Invalid number of bytes for block header. Expecting 3 bytes, got: "
+                         f"{binary_utils.bytes_to_hex_string(block_header_bytes)}")
+
+    lowest_byte = block_header_bytes[0]
+    output = BlockParameters()
+
+    output.last_block = (lowest_byte & 0x01) == 0x01
+    output.block_type = ((lowest_byte >> 1) & 0x03)
+    output.block_size = binary_utils.decode_integer(block_header_bytes + b'\x00') >> 3
+
+    return output

--- a/bin/decompress_file.sh
+++ b/bin/decompress_file.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir ../scratch/
+python3 ../Parser/decompress_raw_file.py ../example_files/first_round_full_file_raw.rec ../scratch/first_round_full-decompressed.rec

--- a/example_files/first_round_full-decompressed.rec
+++ b/example_files/first_round_full-decompressed.rec
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9e79afedcc6928371cea8bb85b7da3ad9c060c239374fdd46a41dde3bc4eb08
+size 190811318

--- a/example_files/first_round_full_file_raw.rec
+++ b/example_files/first_round_full_file_raw.rec
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:880251f61f12a08a8866e8f0db1af73e904b269693d13ecca787e4e9bbad3864
+size 37807155

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+zstandard


### PR DESCRIPTION
Adds a new script that can take a .rec file straight from R6 and decompress it into a readable format

Usage:
```
decompress_raw_file.py [-h] [-z] [-f] input_file output_file

Decompresses an entire .rec file

positional arguments:
  input_file    The file to decompress
  output_file   The file path to write to

optional arguments:
  -h, --help    show this help message and exit
  -z, --is-zst  Indicate that the input file is already in ZST format (no need
                to strip the footer)
  -f, --force   Force the parser to continue despite warnings
```