### PR TITLE
Segment and block parsers

### DIFF
--- a/Parser/binary_utils.py
+++ b/Parser/binary_utils.py
@@ -17,9 +17,8 @@ def decode_integer(hex_bytes):
         raise ValueError(f"ByteString: {bytes_to_hex_string(hex_bytes)} is of incorrect length")
 
 
-def bytes_to_hex_string(hex_bytes):
-    hex_str = hex_bytes.hex().upper()
-    return ' '.join([hex_str[i:i + 4] for i in range(0, len(hex_str), 4)])
+def bytes_to_hex_string(hex_bytes: bytes):
+    return hex_bytes.hex(' ', -2).upper()
 
 
 def print_block(hex_bytes, explanation, args):

--- a/Parser/config.py
+++ b/Parser/config.py
@@ -1,0 +1,2 @@
+
+column_width = 70

--- a/Parser/parse_round_header.py
+++ b/Parser/parse_round_header.py
@@ -1,112 +1,26 @@
 import argparse
+import config
 
-from Parser.binary_utils import decode_integer, print_block
-
-header_properties = []
-
-packet_ids = []
-packet_timestamps = []
-
-
-def read_string(bytestream):
-    string_length_bytes = bytestream.read(8)
-    string_length = decode_integer(string_length_bytes)
-
-    string_bytes = bytestream.read(string_length)
-    string_val = string_bytes.decode('UTF-8')
-
-    return string_length_bytes + string_bytes, string_val
-
-
-def read_packet(bytestream, i):
-    packet_id_bytes = bytestream.read(4)
-    packet_id_num = decode_integer(packet_id_bytes)
-
-    unknown_content_bytes = bytestream.read(4)
-
-    timestamp_bytes = bytestream.read(4)
-
-    timestamp_val = decode_integer(timestamp_bytes)
-
-    packet_ids.append(packet_id_num)
-    packet_timestamps.append(timestamp_val)
-
-    return (
-        packet_id_bytes + unknown_content_bytes + timestamp_bytes,
-        f"Packet #{packet_id_num}, UNKNOWN CONTENT, {timestamp_val}"
-    )
+from Parser.rec_segment import HeaderSegment, MultiKeyValueSegment, MultiBlockSegment
 
 
 def main(args):
+    config.column_width = args.column_width
+
     with open(args.file_path, 'rb') as f:
-        magic_number = f.read(12)
+        header_segment = HeaderSegment.from_bytestream(f)
+        print(header_segment.peek_first_few_blocks())
 
-        if args.show_header:
-            print_block(magic_number, ".REC File Magic Number", args)
-        str_bytes, str_val = read_string(f)
-        if args.show_header:
-            print_block(str_bytes, f'"{str_val}"', args)
+        key_value_segment = MultiKeyValueSegment.from_bytestream(f)
+        print(key_value_segment.peek_first_few_blocks())
 
-        unknown_header_bytes = f.read(8)
-
-        if args.show_header:
-            print_block(unknown_header_bytes, "????? (Purpose unknown)", args)
-
-        number_of_header_properties_bytes = f.read(8)
-
-        number_of_header_properties = decode_integer(number_of_header_properties_bytes)
-
-        if args.show_header:
-            print_block(
-                number_of_header_properties_bytes,
-                f"{number_of_header_properties} key-value string pairs follow...",
-                args
-            )
-
-        for i in range(number_of_header_properties):
-            key_bytes, key_str = read_string(f)
-            val_bytes, val_str = read_string(f)
-
-            header_properties.append((key_str, val_str))
-
-            if args.show_header:
-                print_block(key_bytes + val_bytes, f'"{key_str}": "{val_str}"', args)
-
-        if args.show_body and args.show_header:
-            print("--------------------------" * 5)
-            print("--------------------------" * 5)
-            print("FILE BODY FOLLOWS")
-            print("--------------------------" * 5)
-
-        number_of_packets_bytes = f.read(8)
-        number_of_packets = decode_integer(number_of_packets_bytes)
-        if args.show_body:
-            print_block(number_of_packets_bytes, f"{number_of_packets} packets follow...", args)
-
-        zeros = f.read(8)
-        if args.show_body:
-            print_block(zeros, "Zeros to space between header and body?", args)
-
-        for i in range(number_of_packets - 1):
-            packet_bytes, packet_desc = read_packet(f, i)
-            if args.show_body:
-                print_block(packet_bytes, packet_desc, args)
-
-            if i > args.max_packets:
-                return
-
-        zeros = f.read(8)
-        if args.show_body:
-            print_block(zeros, "Zeros to space between body and footer?", args)
+        fixed_width_segment = MultiBlockSegment.from_bytestream(f, block_size=12, num_padding_bytes=8)
+        print(fixed_width_segment.peek_first_few_blocks())
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Parses the first frame of a R6 .rec file")
     parser.add_argument('file_path', metavar='path', type=str, help="The file to parse")
-    parser.add_argument('-m', '--max-packets', default=200, type=int)
-    parser.add_argument('-H', '--show-header', action='store_true')
-    parser.add_argument('-B', '--show-body', action='store_true')
-    parser.add_argument('-S', '--hide-source-bytes', action='store_true')
     parser.add_argument('-c', '--column-width', default=70, type=int)
 
     main(parser.parse_args())

--- a/Parser/rec_block.py
+++ b/Parser/rec_block.py
@@ -1,0 +1,159 @@
+import io
+from typing import BinaryIO
+
+from Parser.binary_utils import bytes_to_hex_string, decode_integer
+import config
+
+
+class RecBlock:
+    """Base class representing a .REC 'block' - a sequence of bytes representing an atomic unit of data in
+    a .REC file
+
+    Stores the source bytes, and can be overridden to implement the extraction of useful information in dictionary
+    form (see value())
+    """
+    @staticmethod
+    def from_bytestream(bytestream: BinaryIO, length: int):
+        try:
+            int(length)
+        except TypeError:
+            raise ValueError("Cannot parse a block using RecBlock unless a length is provided")
+
+        content_bytes = bytestream.read(length)
+        return RecBlock(content_bytes)
+
+    def __init__(self, src_bytes: bytes):
+        self.src_bytes = src_bytes
+
+    def __repr__(self):
+        return f"RecBlock('{bytes_to_hex_string(self.src_bytes)}')"
+
+    def __str__(self, explanation="Unknown block"):
+        hex_string = bytes_to_hex_string(self.src_bytes)
+        if len(hex_string) > (config.column_width - 10):
+            hex_string = hex_string[:config.column_width - 13] + "..."
+
+        out_str = hex_string
+        out_str += ' ' * (config.column_width - len(hex_string))
+
+        out_str += explanation
+        return out_str
+
+    @property
+    def value(self):
+        """Returns a dict with key-value pairs representing the data stored in this block"""
+        raise NotImplementedError("Base class RecBlock cannot interpret the bytes in a REC block. "
+                                  "Override value() and implement parsing logic for the byte sequence.")
+
+
+class ExpectedBytesBlock(RecBlock):
+    """A block that always contains the same bytes. Verifies that the bytes are read in as expected. Can be
+    used to detect corruption"""
+
+    @staticmethod
+    def from_bytestream(bytestream: BinaryIO, expected_bytes: bytes):
+        read_bytes = bytestream.read(len(expected_bytes))
+
+        if read_bytes != expected_bytes:
+            raise ValueError(f"Received bytes ({bytes_to_hex_string(read_bytes)}) did not "
+                             f"match expected bytes ({bytes_to_hex_string(expected_bytes)})")
+
+        return ExpectedBytesBlock(read_bytes)
+
+    def __init__(self, src_bytes: bytes, expected_bytes=None):
+        if expected_bytes is None:
+            # TODO: Issue warning that no assertion is being performed?
+            expected_bytes = src_bytes
+
+        if src_bytes != expected_bytes:
+            raise ValueError(f"Received bytes ({bytes_to_hex_string(src_bytes)}) did not "
+                             f"match expected bytes ({bytes_to_hex_string(expected_bytes)})")
+        super().__init__(src_bytes)
+
+    def __repr__(self):
+        return f"ExpectedBytesBlock('{bytes_to_hex_string(self.src_bytes)}')"
+
+    def __str__(self, explanation=f'As expected'):
+        return super().__str__(explanation)
+
+    @property
+    def value(self):
+        return dict({})
+
+
+class MagicNumberBlock(ExpectedBytesBlock):
+    """A block containing the .REC file magic number"""
+    @staticmethod
+    def from_bytestream(bytestream: BinaryIO):
+        expected_bytes = b'dissect\x00\x04\x00\x00\x00'
+        return MagicNumberBlock(bytestream.read(len(expected_bytes)), expected_bytes)
+
+    def __repr__(self):
+        return f"MagicNumberBlock('{bytes_to_hex_string(self.src_bytes)}')"
+
+    def __str__(self, explanation=f'.REC file magic number'):
+        return super().__str__(explanation)
+
+
+class StringBlock(RecBlock):
+    """A .REC block containing a single string (prepended by the length of the string)"""
+    @staticmethod
+    def from_bytestream(bytestream: BinaryIO, num_length_bytes=8):
+        string_length_bytes = bytestream.read(num_length_bytes)
+        string_length = decode_integer(string_length_bytes)
+        string_content_bytes = bytestream.read(string_length)
+        string_content = string_content_bytes.decode('UTF-8')
+
+        return StringBlock(string_length_bytes + string_content_bytes, string_length, string_content)
+
+    def __init__(self, src_bytes: bytes, length: int, content: str):
+        super().__init__(src_bytes)
+        self.length = length
+        self.content = content
+
+    def __repr__(self):
+        return f"StringBlock('{self.content}')"
+
+    def __str__(self, explanation=None):
+        if explanation is None:
+            explanation = f'"{self.content}"'
+        return super().__str__(explanation)
+
+    @property
+    def value(self):
+        return {
+            'length': self.length,
+            'content': self.content
+        }
+
+
+class StringKeyValueBlock(RecBlock):
+    """A .REC block composed of two StringBlocks, where the first represents the key, and the
+    second represents the value"""
+
+    @staticmethod
+    def from_bytestream(bytestream: BinaryIO):
+        key_block = StringBlock.from_bytestream(bytestream)
+        value_block = StringBlock.from_bytestream(bytestream)
+
+        return StringKeyValueBlock(key_block, value_block)
+
+    def __init__(self, key_block: StringBlock, value_block: StringBlock):
+        super().__init__(key_block.src_bytes + value_block.src_bytes)
+        self.key_block = key_block
+        self.value_block = value_block
+
+    def __repr__(self):
+        return f"KeyValueBlock('{self.key_block.value['content']}': '{self.value_block.value['content']}')"
+
+    def __str__(self, explanation=None):
+        if explanation is None:
+            explanation = f"'{self.key_block.value['content']}': '{self.value_block.value['content']}'"
+        return super().__str__(explanation)
+
+    @property
+    def value(self):
+        return {
+            'key': self.key_block.value['content'],
+            'value': self.value_block.value['content']
+        }

--- a/Parser/rec_segment.py
+++ b/Parser/rec_segment.py
@@ -115,6 +115,8 @@ class MultiBlockSegment(SegmentWithHeader):
 
     @staticmethod
     def parse_block(bytestream: BinaryIO, block_size: int):
+        if block_size is None:
+            raise ValueError("block_size is required for MultiBlockSegment")
         return RecBlock.from_bytestream(bytestream, block_size)
 
     def __repr__(self):

--- a/Parser/rec_segment.py
+++ b/Parser/rec_segment.py
@@ -1,0 +1,165 @@
+from typing import List
+
+from typing.io import BinaryIO
+
+from Parser.binary_utils import decode_integer
+from Parser.rec_block import MagicNumberBlock, StringBlock, RecBlock, StringKeyValueBlock
+
+
+class RecSegment:
+    """Abstract base class representing a .REC 'segment' - an ordered collection of .REC blocks"""
+    @staticmethod
+    def from_bytestream(bytestream: BinaryIO):
+        raise NotImplementedError("Abstract base class RecSegment cannot parse segment from bytestream. Override"
+                                  "from_bytestream() in a child class and implement parsing logic")
+
+    def __init__(self, content_blocks: List[RecBlock]):
+        self.content_blocks = content_blocks
+
+    def __repr__(self):
+        return f'RecSegment({self.content_blocks})'
+
+    def __str__(self):
+        out_str = ""
+        for block in self.content_blocks:
+            out_str += "--------------------------" * 5 + '\n'
+            out_str += str(block) + '\n'
+        out_str += "--------------------------" * 5 + '\n\n\n'
+
+        return out_str
+
+    def peek_first_few_blocks(self, num_blocks=10):
+        out_str = ""
+        for i in range(num_blocks):
+            if i >= len(self.content_blocks):
+                break
+            out_str += "--------------------------" * 5 + '\n'
+            out_str += str(self.content_blocks[i]) + '\n'
+        out_str += "--------------------------" * 5 + '\n'
+
+        return out_str
+
+
+class HeaderSegment(RecSegment):
+    @staticmethod
+    def from_bytestream(bytestream: BinaryIO):
+        magic_number = MagicNumberBlock.from_bytestream(bytestream)
+        version_string = StringBlock.from_bytestream(bytestream)
+        unknown_block = RecBlock.from_bytestream(bytestream, 8)
+
+        return HeaderSegment([magic_number, version_string, unknown_block])
+
+    def __repr__(self):
+        return f'HeaderSegment({self.content_blocks})'
+
+    def __str__(self):
+        out_str = "--------------------------" * 5 + '\n'
+        out_str += "--------------------------" * 5 + '\n'
+        out_str += ' '* 55 + "Header Segment\n"
+        out_str += "--------------------------" * 5 + '\n'
+        out_str += super().__str__()
+        return out_str
+
+    def peek_first_few_blocks(self, num_blocks=10):
+        out_str = "--------------------------" * 5 + '\n'
+        out_str += "--------------------------" * 5 + '\n'
+        out_str += ' ' * 55 + "Header Segment\n"
+        out_str += "--------------------------" * 5 + '\n'
+        out_str += super().peek_first_few_blocks(num_blocks)
+        return out_str
+
+
+class SegmentWithHeader(RecSegment):
+    def __init__(self, header_blocks: List[RecBlock], content_blocks: List[RecBlock]):
+        super().__init__(content_blocks)
+        self.header_blocks = header_blocks
+
+    def __str__(self):
+        out_str = ""
+        if len(self.header_blocks):
+            out_str += "--------------------------" * 5 + '\n'
+            for block in self.header_blocks:
+                out_str += str(block) + '\n'
+            out_str += "--------------------------" * 5 + '\n'
+
+        out_str += super().__str__()
+        return out_str
+
+    def peek_first_few_blocks(self, num_blocks=10):
+        out_str = ""
+        if len(self.header_blocks):
+            out_str += "--------------------------" * 5 + '\n'
+            for block in self.header_blocks:
+                out_str += str(block) + '\n'
+            out_str += "--------------------------" * 5 + '\n'
+
+        out_str += super().peek_first_few_blocks(num_blocks)
+        return out_str
+
+
+class MultiBlockSegment(SegmentWithHeader):
+    @classmethod
+    def from_bytestream(cls, bytestream: BinaryIO, num_length_bytes=8, block_size=None, num_padding_bytes=0):
+        segment_length_bytes = bytestream.read(num_length_bytes)
+        segment_length = decode_integer(segment_length_bytes)
+
+        header_blocks = []
+        if num_padding_bytes > 0:
+            header_blocks.append(RecBlock.from_bytestream(bytestream, length=num_padding_bytes))
+
+        content_blocks = []
+        for i in range(segment_length):
+            content_blocks.append(cls.parse_block(bytestream, block_size))
+
+        return cls(header_blocks, content_blocks)
+
+    @staticmethod
+    def parse_block(bytestream: BinaryIO, block_size: int):
+        return RecBlock.from_bytestream(bytestream, block_size)
+
+    def __repr__(self):
+        return f'MultiBlockSegment({self.content_blocks})'
+
+    def __str__(self):
+        out_str = "--------------------------" * 5 + '\n'
+        out_str += "--------------------------" * 5 + '\n'
+        out_str += ' '* 45 + f"Multi-Block Segment ({len(self.content_blocks)} blocks follow)\n"
+        out_str += "--------------------------" * 5 + '\n'
+        out_str += super().__str__()
+        return out_str
+
+    def peek_first_few_blocks(self, num_blocks=10):
+        out_str = "--------------------------" * 5 + '\n'
+        out_str += "--------------------------" * 5 + '\n'
+        out_str += ' '* 45 + f"Multi-Block Segment ({len(self.content_blocks)} blocks follow)\n"
+        out_str += "--------------------------" * 5 + '\n'
+        out_str += super().peek_first_few_blocks(num_blocks)
+        return out_str
+
+
+class MultiKeyValueSegment(MultiBlockSegment):
+    @staticmethod
+    def parse_block(bytestream: BinaryIO, block_size: int):
+        if block_size is not None:
+            raise ValueError("block_size is not supported when using MultiKeyValueSegment")
+
+        return StringKeyValueBlock.from_bytestream(bytestream)
+
+    def __repr__(self):
+        return f'MultiKeyValueSegment({self.content_blocks})'
+
+    def __str__(self):
+        out_str = "--------------------------" * 5 + '\n'
+        out_str += "--------------------------" * 5 + '\n'
+        out_str += ' '* 45 + f"Multi-Key-Value Segment ({len(self.content_blocks)} key-value pairs follow)\n"
+        out_str += "--------------------------" * 5 + '\n'
+        out_str += SegmentWithHeader.__str__(self)
+        return out_str
+
+    def peek_first_few_blocks(self, num_blocks=10):
+        out_str = "--------------------------" * 5 + '\n'
+        out_str += "--------------------------" * 5 + '\n'
+        out_str += ' '* 45 + f"Multi-Key-Value Segment ({len(self.content_blocks)} key-value pairs follow)\n"
+        out_str += "--------------------------" * 5 + '\n'
+        out_str += SegmentWithHeader.peek_first_few_blocks(self, num_blocks)
+        return out_str


### PR DESCRIPTION
Adds a system of high-level parsing objects that can be used to easily extract blocks and segments from a file. For example, the main logic from `parse_round_header.py`  can now be written as:

```python
  with open(args.file_path, 'rb') as f:
      header_segment = HeaderSegment.from_bytestream(f)
      key_value_segment = MultiKeyValueSegment.from_bytestream(f)
      fixed_width_segment = MultiBlockSegment.from_bytestream(f, block_size=12, num_padding_bytes=8)
```